### PR TITLE
Feat: Implement local report caching and sync

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,18 +1,22 @@
 // Trafficlites - MVP React Native App with Map, Markers, and Report Button // Using Expo
 
 import React, { useState, useEffect } from 'react';
-import { View, StyleSheet, Text, Button, Alert, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Text, Alert, TouchableOpacity } from 'react-native'; // Removed Button
 import MapView, { Marker } from 'react-native-maps';
 import * as Location from 'expo-location';
+import * as SQLite from 'expo-sqlite';
+
+// Open or create a database file
+const db = SQLite.openDatabase('local_reports.db');
 
 export default function App() {
   const [location, setLocation] = useState(null);
   const [errorMsg, setErrorMsg] = useState(null);
   const [reportStatus, setReportStatus] = useState('');
 
-  // Dummy traffic light data
-  const trafficLights = [
-    { id: 1, title: 'Main & 1st Ave', coords: { latitude: -26.6505, longitude: 153.0908 }, status: 'green', },
+  // Initialize DB and get location
+  // const trafficLights = [ // Dummy data, can be removed if not used for markers anymore
+  //   { id: 1, title: 'Main & 1st Ave', coords: { latitude: -26.6505, longitude: 153.0908 }, status: 'green', },
     { id: 2, title: 'Beach Rd & 2nd St', coords: { latitude: -26.6525, longitude: 153.0915 }, status: 'red', },
     { id: 3, title: 'Park Lane & 3rd Blvd', coords: { latitude: -26.6515, longitude: 153.0925 }, status: 'yellow', },
   ];
@@ -30,37 +34,153 @@ export default function App() {
     })();
   }, []);
 
-  const reportLightStatus = (status) => {
-    setReportStatus(status);
-    Alert.alert('Reported', `You reported: ${status.toUpperCase()} light`);
-
-    // Example POST request (commented out - backend needed)
-
-    fetch('http://localhost:4000/report', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        latitude: location.latitude,
-        longitude: location.longitude,
-        status: status,
-      }),
-})
-.then(response => {
-  if (!response.ok) {
-    // If the server response is not OK (e.g., 404, 500), throw an error
-    console.warn(`API request failed with status ${response.status}`);
-    // Potentially update UI to show error to user
-    // Alert.alert('Error', 'Failed to report status. Please try again.');
-    return; // Or throw new Error('Network response was not ok');
-  }
-  // console.log('Report successful', response); // Or handle successful response data
-})
-.catch(error => {
-  console.error('Error reporting light status:', error);
-  // Update UI to show error to user
-  // Alert.alert('Error', 'Could not connect to server to report status.');
+  // Effect for DB initialization and initial sync
+  useEffect(() => {
+    db.transaction(tx => {
+      tx.executeSql(
+        `CREATE TABLE IF NOT EXISTS pending_reports (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          latitude REAL NOT NULL,
+          longitude REAL NOT NULL,
+          status TEXT NOT NULL,
+          timestamp TEXT NOT NULL,
+          synced INTEGER DEFAULT 0
+        );`,
+        [], // Parameters
+        () => {
+          console.log('Table pending_reports initialized successfully');
+          syncPendingReports(); // Sync on app start after table is confirmed
+        },
+        (_, error) => console.error('Error initializing table pending_reports:', error)
+      );
     });
+  }, []);
 
+  const syncPendingReports = async () => {
+    console.log('Attempting to sync pending reports...');
+    db.transaction(tx => {
+      tx.executeSql(
+        'SELECT * FROM pending_reports WHERE synced = 0;',
+        [],
+        async (_, { rows: { _array: pendingReports } }) => {
+          if (pendingReports.length === 0) {
+            console.log('No pending reports to sync.');
+            return;
+          }
+          console.log(`Found ${pendingReports.length} reports to sync.`);
+
+          for (const report of pendingReports) {
+            try {
+              const response = await fetch('http://localhost:4000/report', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  latitude: report.latitude,
+                  longitude: report.longitude,
+                  status: report.status,
+                  timestamp: report.timestamp, // Send original timestamp for potential backend processing
+                }),
+              });
+
+              if (response.ok) {
+                console.log(`Report ID ${report.id} (from local DB) synced successfully to server.`);
+                // Mark as synced in local DB
+                db.transaction(updateTx => {
+                  updateTx.executeSql(
+                    'UPDATE pending_reports SET synced = 1 WHERE id = ?;',
+                    [report.id],
+                    (_, { rowsAffected }) => {
+                      if (rowsAffected > 0) {
+                        console.log(`Local report ID ${report.id} marked as synced.`);
+                      }
+                    },
+                    (_, error) => console.error(`Error marking report ID ${report.id} as synced:`, error)
+                  );
+                });
+              } else {
+                console.warn(`API sync failed for local report ID ${report.id} with status ${response.status}.`);
+              }
+            } catch (error) {
+              console.error(`Network or other error syncing report ID ${report.id}:`, error);
+            }
+          }
+        },
+        (_, error) => console.error('Error fetching pending reports from SQLite:', error)
+      );
+    });
+  };
+
+  const reportLightStatus = (reportedStatus) => {
+    if (!location) {
+      Alert.alert("Location not available", "Cannot report light status without location.");
+      return;
+    }
+
+    const currentTimestamp = new Date().toISOString();
+    setReportStatus(reportedStatus.toUpperCase()); // Update UI state
+
+    db.transaction(tx => {
+      tx.executeSql(
+        'INSERT INTO pending_reports (latitude, longitude, status, timestamp, synced) VALUES (?, ?, ?, ?, 0);',
+        [location.latitude, location.longitude, reportedStatus, currentTimestamp],
+        (_, { insertId, rowsAffected }) => {
+          if (rowsAffected > 0) {
+            console.log(`Report saved locally with ID: ${insertId}, Status: ${reportedStatus}`);
+            Alert.alert('Reported Locally', `Light status '${reportedStatus.toUpperCase()}' saved locally.`);
+
+            // Attempt to send to server
+            fetch('http://localhost:4000/report', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                latitude: location.latitude,
+                longitude: location.longitude,
+                status: reportedStatus,
+                // timestamp: currentTimestamp // Server generates its own timestamp upon receipt
+              }),
+            })
+            .then(response => {
+              if (response.ok) {
+                console.log(`Report (local ID: ${insertId}) synced to server successfully.`);
+                // Update local entry to synced = 1
+                db.transaction(updateTx => {
+                  updateTx.executeSql(
+                    'UPDATE pending_reports SET synced = 1 WHERE id = ?;',
+                    [insertId],
+                    (_, { rowsAffected: updatedRows }) => {
+                      if (updatedRows > 0) {
+                        console.log(`Local report ID ${insertId} marked as synced.`);
+                      }
+                    },
+                    (_, error) => console.error(`Error marking report ID ${insertId} as synced:`, error)
+                  );
+                });
+                return response.json(); // Or handle response data
+              } else {
+                console.warn(`API request failed for local ID ${insertId} with status ${response.status}. Report remains unsynced.`);
+                // Alert.alert('Sync Failed', 'Could not sync report to server. It remains saved locally.');
+              }
+            })
+            .catch(error => {
+              console.error(`Error syncing current report (local ID: ${insertId}) to server:`, error);
+              // Alert.alert('Sync Error', 'Error connecting to server. Report remains saved locally.');
+            })
+            .finally(() => {
+              // Attempt to sync any other pending reports after this operation
+              syncPendingReports();
+            });
+          } else {
+            console.error('Failed to save report locally (no rows affected).'); // This console log is fine
+            Alert.alert('Save Failed', 'Could not save report locally.'); // User facing alert
+          }
+        },
+        (_, error) => {
+          console.error('SQLite error when saving report:', error);
+          Alert.alert('Database Error', 'Failed to save report to local database.');
+          return true; // Rollback transaction
+        }
+      );
+    });
   };
 
   return (


### PR DESCRIPTION
- Add `expo-sqlite` for local database storage.
- Initialize `pending_reports` table in SQLite on app start to store reports locally.
- Modify `reportLightStatus` function:
    - Reports are now first saved to the local `pending_reports` table with `synced=0`.
    - An attempt is then made to send the report to the backend server.
    - If server sync is successful, the local report's `synced` status is updated to `1`.
- Implement `syncPendingReports` function:
    - Queries local DB for unsynced reports.
    - Attempts to send each unsynced report to the server.
    - Updates local `synced` status upon successful server response.
- Call `syncPendingReports` on app startup and after each report attempt to ensure pending reports are processed when network is available.