### PR TITLE
Fix: Correct eas.json android production buildType to app-bundle

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -26,7 +26,7 @@
     "production": {
       "distribution": "store",
       "android": {
-        "buildType": "aab"
+        "buildType": "app-bundle"
       },
       "ios": {},
       "env": {}


### PR DESCRIPTION
Ensures that the production profile for Android in eas.json uses the valid `buildType: "app-bundle"` instead of `aab` to prevent validation errors with EAS CLI.