### PR TITLE
Feat(backend): Add axios to Backend-api dependencies

### DIFF
--- a/Backend-api/package.json
+++ b/Backend-api/package.json
@@ -11,7 +11,8 @@
     "express": "^4.17.1",
     "cors": "^2.8.5",
     "pg": "^8.7.1",
-    "dotenv": "^10.0.0"
+    "dotenv": "^10.0.0",
+    "axios": "^0.21.4"
   },
   "devDependencies": {},
   "author": "",


### PR DESCRIPTION
Adds axios to Backend-api/package.json to ensure it can be installed for the backend server, resolving potential 'Cannot find module' errors.

The user will still need to run `npm install` or `npm install axios` within the `Backend-api` directory locally to populate its `node_modules` folder.