### PR TITLE
Docs: Add EAS build instructions to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -130,3 +130,35 @@ This guide will walk you through setting up the Trafficlites application, includ
 - ✅ Traffic light markers and directions
 - ✅ Codebase cleaned and refactored for maintainability
 - 🚧 Data prediction and learning model – coming soon
+
+---
+
+### Building the App (EAS)
+
+To create a standalone build of the application for Android or iOS, this project uses Expo Application Services (EAS).
+
+1.  **Install EAS CLI:**
+    If you don't have it installed, get it via npm:
+    ```bash
+    npm install -g eas-cli
+    ```
+
+2.  **Log In to Expo:**
+    You need to be authenticated with your Expo account. For interactive use, run:
+    ```bash
+    eas login
+    ```
+    For non-interactive environments (like CI/CD), you must set an `EXPO_TOKEN` environment variable with a valid personal access token.
+
+3.  **Configure EAS Update:**
+    Before the first build, the project needs to be configured for EAS Update. This is a one-time setup.
+    ```bash
+    eas update:configure
+    ```
+
+4.  **Start a Build:**
+    To start a cloud build for Android, run:
+    ```bash
+    eas build --platform android --profile preview
+    ```
+    You can replace `android` with `ios` or `all`. The `preview` profile is configured for internal distribution as an APK. Check `eas.json` for other available build profiles.


### PR DESCRIPTION
This change adds a new section to the `README.md` file that documents the process for building the application using Expo Application Services (EAS).

The new section includes instructions for:
- Installing `eas-cli`
- Logging into Expo
- Configuring EAS Update
- Starting a build