### PR TITLE
fix(eas): Correct Android buildType in production profile

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -15,7 +15,7 @@
     "production": {
       "distribution": "store",
       "android": {
-        "buildType": "aab"
+        "buildType": "app-bundle"
       },
       "ios": {
         "simulator": false


### PR DESCRIPTION
The EAS CLI validates the entire eas.json file before starting a build, even when only a specific profile is targeted. The Android production build profile contained an invalid `buildType` of "aab", which should be "app-bundle".

This error prevented any builds, including preview builds, from starting. This commit corrects the `buildType` to unblock all EAS builds.