### PR TITLE
fix: Prevent crash on launch due to missing BACKEND_URL

### DIFF
--- a/App.js
+++ b/App.js
@@ -120,12 +120,17 @@ export default function App() {
   // --- Effects ---
   useEffect(() => {
     const checkServerStatus = async () => {
+      const backendUrl = Constants.expoConfig?.extra?.backendUrl;
+      if (!backendUrl) {
+        setServerStatus('Disconnected (URL not set)');
+        return;
+      }
+
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 5000); // 5-second timeout
 
       try {
-        // Note: Using a placeholder. Replace with your actual backend health check endpoint.
-        const response = await fetch(Constants.expoConfig.extra.backendUrl, { signal: controller.signal });
+        const response = await fetch(backendUrl, { signal: controller.signal });
         clearTimeout(timeoutId);
         if (response.ok) {
           setServerStatus('Connected');


### PR DESCRIPTION
This commit adds a check to the `checkServerStatus` function in `App.js` to prevent the app from crashing if the `BACKEND_URL` environment variable is not set.

If the `BACKEND_URL` is not defined, the app will now show a "Disconnected (URL not set)" status instead of crashing.